### PR TITLE
Small security improvements

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -27,7 +27,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "homebox.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- if .Values.serviceAccount.enable -}}
+      serviceAccountName: {{ include "homebox.serviceAccountName" . -}}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "homebox.fullname" . }}
   labels:
     {{- include "homebox.labels" . | nindent 4 }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -31,7 +34,12 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ .Values.image.repository }} 
+          {{- if .Values.image.digest -}} 
+              @ {{- .Values.image.digest -}}
+          {{- else -}}
+              : {{- .Values.image.tag | default .Chart.AppVersion -}}
+          {{- end }} 
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "homebox.labels" . | nindent 4 }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "homebox.fullname" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
   annotations:
   {{- with .Values.persistence.annotations  }}
   {{ toYaml . | nindent 4 }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "homebox.fullname" . }}
   labels:
     {{- include "homebox.labels" . | nindent 4 }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "homebox.serviceAccountName" . }}
   labels:
     {{- include "homebox.labels" . | nindent 4 }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -3,12 +3,14 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+# namespace: homebox
 
 image:
   repository: ghcr.io/hay-kot/homebox
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # digest: "sha256:a929rce867e9bec2fd8d54486be6b6c41212b377c632003fa6a62ab38ae9156d"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -27,7 +29,7 @@ persistence:
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -37,28 +39,28 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+  # fsGroup: 65532
 
-securityContext: {}
+securityContext: {} 
   # capabilities:
-  #   drop:
-  #   - ALL
+    # drop:
+    # - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-  # runAsUser: 1000
+  # runAsUser: 65532
 
 service:
   type: ClusterIP
   port: 80
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: chart-example.local 
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,7 @@ persistence:
   # subPath: "" # only mount a subpath of the Volume into the pod
 
 serviceAccount:
+  enable: false
   # Specifies whether a service account should be created
   create: false
   # Annotations to add to the service account

--- a/values.yaml
+++ b/values.yaml
@@ -54,7 +54,7 @@ service:
   port: 80
 
 ingress:
-  enabled: true
+  enabled: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
First of all, thanks a lot for this work, it save me _a lot_ of time!

This small PR aims to do the following:

- Support image referenced with digest (e.g., `repo@sha256:abc[...]`)
- Add `namespace` to values, this is to facilitate `flux` integration (where we cannot specify `-n NS` argument)
- Disables by default the `serviceAccount`. As far as I can tell, there is no reason for this application to talk to API server (or any other application really). I have added an `enable` flag that if set to false will fully disable the serviceAccount. In addition the deployment will have automountServiceAccountToken set to false.
- Change the 'commented' userID. This is to match what would be the result of merging https://github.com/hay-kot/homebox/pull/372 (build distroless image).

Let me know what you think about this, in case I can revert/add some changes!